### PR TITLE
Add handling of SIGTERM command

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -91,3 +91,8 @@ process.on('SIGINT', () => {
   close();
   process.exit();
 });
+
+process.on('SIGTERM', () => {
+  close();
+  process.exit();
+});


### PR DESCRIPTION
Reduces the shut down time of docker-compose down by 10 seconds by properly shutting down on SIGTERM.